### PR TITLE
Add a documentation object to main eslint

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,5 +8,6 @@
 module.exports = {
     linter: require("./eslint"),
     CLIEngine: require("./cli-engine"),
-    validator: require("./config-validator")
+    validator: require("./config-validator"),
+    docs: require("./docs")
 };

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Providing easy access to rule documentation
+ */
+
+"use strict";
+
+var fs = require("fs"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Privates
+//------------------------------------------------------------------------------
+
+var docs = Object.create(null);
+
+function load() {
+    var docsDir = path.join(__dirname, "../docs/rules");
+
+    fs.readdirSync(docsDir).forEach(function(file) {
+        var content = fs.readFileSync(docsDir + "/" + file, "utf8");
+        docs[file.slice(0, -3)] = content;
+    });
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+exports.get = function(ruleId) {
+    return docs[ruleId];
+};
+
+//------------------------------------------------------------------------------
+// Initialization
+//------------------------------------------------------------------------------
+
+// loads existing docs
+load();

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "README.md",
     "bin",
     "conf",
+    "docs",
     "lib"
   ],
   "repository": {

--- a/tests/lib/docs.js
+++ b/tests/lib/docs.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Tests docs.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    docs = require("../../lib/docs");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("docs", function() {
+    describe("get()", function() {
+        it("should return the body of a given rule's documentation", function() {
+            var doc = docs.get("complexity");
+            assert.isString(doc);
+            assert.match(doc, /# Limit Cyclomatic Complexity/);
+        });
+    });
+});


### PR DESCRIPTION
This change aims to make markdown [documentation](https://github.com/eslint/eslint/tree/master/docs/rules) for each issue more accessible for generating content. 

Implementation:
1) update `package.json` to include docs as part of package
2) add a `docs` function that returns an object containing rule name and markdown content.

<img width="1124" alt="screen shot 2015-10-17 at 1 11 46 am" src="https://cloud.githubusercontent.com/assets/8718443/10557241/bd556ca4-7471-11e5-8d83-2cbc537b689b.png">

you can access markdown content by checkname:

<img width="1132" alt="screen shot 2015-10-17 at 1 53 46 am" src="https://cloud.githubusercontent.com/assets/8718443/10557249/0b852bd0-7472-11e5-828a-05ee8af8b078.png">

cc @codeclimate/review @GordonDiggs
