### PR TITLE
Add support for Airbnb config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -148,9 +148,11 @@ function readConfigFromFile(filePath) {
             filePath = "eslint-config-" + filePath;
         }
 
-        // TODO: support other configs
-        // config = util.mergeConfigs(config, require(filePath));
+        if (filePath.match(/^eslint-config-airbnb.*/)) {
+          config = util.mergeConfigs(config, require(filePath));
+        }
     }
+
     return config;
 }
 


### PR DESCRIPTION
This adds support for `eslint-config-airbnb`.

We have to white list any path starting with `eslint-config-airbnb` because it recursively extends on paths starting with its own package name.
