### PR TITLE
Don't throw an error on non-permitted extensions

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -329,11 +329,7 @@ function applyExtends(config, filePath) {
             debug("Loading " + parentPath);
             return ConfigOps.merge(load(parentPath), previousValue);
         } catch (e) {
-            // If the file referenced by `extends` failed to load, add the path to the
-            // configuration file that referenced it to the error message so the user is
-            // able to see where it was referenced from, then re-throw
-            e.message += "\nReferenced from: " + filePath;
-            throw e;
+            return {}; // suppress error for unsupported extensions
         }
 
     }, config);


### PR DESCRIPTION
Ignore config extensions that aren't airbnb
@codeclimate/review 

Similar to: 
https://github.com/codeclimate/eslint/commit/fd49900c20691ecceaf962f03d9b0929ec0921ce

Fixes: 
https://codeclimate.com/repos/56746dd23a2003408100006b/builds/1
